### PR TITLE
Update NYUSIM for Compatibility with ns-3.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # NYUSIM_in_ns3
-Release v1.0 for NYUSIM in ns-3
+Release v1.1 for NYUSIM in ns-3 (ns-3 version 3.42)
 
 NYUSIM is a groundbreaking open-source sub-THz and mmWave wireless channel simulator that is free to download and use by global industrial and academic institutions.NYUSIM is specifically designed to help accelerate the standardization efforts for 6G wireless communications, which is expected to kick off in 2025. NYUSIM comes with a myriad of new features that allow for the simulation of wireless channels in various scenarios, including urban microcell (UMi), urban macrocell (UMa), rural macrocell (RMa), indoor hotspot (InH), and indoor factory (InF) environments. The simulator offers indoor and outdoor channel models for each scenario, supporting carrier frequencies ranging from 0.5 to 150 GHz with an RF bandwidth from 0 Hz (CW) to 1 GHz. The inclusion of drop-based channel simulations for all five simulation scenarios further enhances the simulator's capabilities. NYUSIM in ns-3 based on the very popular and widely used open-source MATLAB based channel simulator "NYUSIM". Since its first release in 2016, NYUSIM has been downloaded more than 100,000 times and is used an alternative to 3GPP channel models.
 
@@ -9,9 +9,9 @@ Advantage of using NYUSIM
 <p class = "justified-text">Currently, ns-3 uses the 3GPP TR 38.901 SCM to model the wireless channel for the frequency range of 0.5-100 GHz for all 3GPP-listed scenarios namely urban microcell (UMi), urban microcell (UMa), rural microcell (RMa), indoor hotspot (InH), and indoor factory (InF). Research conducted at NYU WIRELESS shows that 3GPP SCM provides an oversimplification of the actual wireless channel in outdoor scenarios. In addition, the limited frequency range of the 3GPP SCM does not allow researchers to study future networks above 100 GHz. Furthermore, there needs to be more understanding of how the wireless channel model impacts overall network performance as ns-3 users are restricted to using only the 3GPP SCM for simulations. To enable the research community to explore and analyze networks of the future based on real-world channel measurement-based models that cover the frequency range of 0.5-150 GHz in 3GPP-listed scenarios, we present the implementation of drop-based NYUSIM in ns-3.</p>
 
 # Steps to Use NYUSIM in ns-3 mainline
-Steps to use NYUSIM in ns-3 on ns-3 mainline: (Successfully Tested on ns-3 version 3.39)
+Steps to use NYUSIM in ns-3 on ns-3 mainline: (Updated and successfully Tested on ns-3 version **3.42**)
 
-1. Download/Clone ns-3 mainline on your local machine. NYUSIM files are tested on ns-3 version 3.39 thus users are recommended to download ns-3 version 3.39.
+1. Download/Clone ns-3 mainline on your local machine. NYUSIM files are tested on ns-3 version 3.42 thus users are recommended to download ns-3 version 3.42.
 2. Copy all the files from the current repository present in the directory propagation/model to ns-3 mainline src/propagation/model
 3. Copy all the files from the current repository present in the directory propagation/example to ns-3 mainline src/propagation/examples
 4. On ns-3 mainline in the directory src/propagation add the following lines to the CMakeLists.txt file under:<br>
@@ -33,7 +33,7 @@ Steps to use NYUSIM in ns-3 on ns-3 mainline: (Successfully Tested on ns-3 versi
 8. You can run the example files from Step 3 or Step 6 to see the usage of NYUSIM channel model from the ns-3-dev folder using: <br> ./ns3 run src/spectrum/examples/nyu-channel-example
 
 # Steps to Use NYUSIM in ns3-mmWave module
-Steps to use NYUSIM in ns-3 on ns3-mmWave module: (Successfully Tested on ns3-mmWave module version 3.38)
+Steps to use NYUSIM in ns-3 on ns3-mmWave module: (Successfully Tested on ns3-mmWave module version 3.38) (Still not updated to ns3-3.42)
 
 1. Download/Clone <a href="https://github.com/nyuwireless-unipd/ns3-mmwave">ns3-mmWave module</a> mainline on your local machine. NYUSIM files are tested on ns3-mmWave module version 3.38 thus users are recommended to download ns3-mmWave module version 3.38.
 2. Copy all the files from the current repository present in the directory propagation/model to ns3-mmwave/src/propagation/model

--- a/spectrum/example/nyu-channel-example.cc
+++ b/spectrum/example/nyu-channel-example.cc
@@ -98,7 +98,7 @@ DoBeamforming(Ptr<NetDevice> thisDevice,
     double vAngleRadian = completeAngle.GetInclination(); // the elevation angle
 
     // retrieve the number of antenna elements and resize the vector
-    uint64_t totNoArrayElements = thisAntenna->GetNumberOfElements();
+    uint64_t totNoArrayElements = thisAntenna->GetNumElems();
     PhasedArrayModel::ComplexVector antennaWeights(totNoArrayElements);
 
     // the total power is divided equally among the antenna elements
@@ -160,11 +160,12 @@ ComputeSnr(const ComputeSnrParams& params)
     NS_ASSERT_MSG(params.rxAntenna, "params.rxAntenna is nullptr!");
 
     // apply the fast fading and the beamforming gain
-    Ptr<SpectrumValue> rxPsd = m_spectrumLossModel->CalcRxPowerSpectralDensity(txParams,
+    Ptr<SpectrumSignalParameters> rxParams = m_spectrumLossModel->CalcRxPowerSpectralDensity(txParams,
                                                                                params.txMob,
                                                                                params.rxMob,
                                                                                params.txAntenna,
                                                                                params.rxAntenna);
+    Ptr<SpectrumValue> rxPsd = rxParams->psd;
     NS_LOG_DEBUG("Average rx power " << 10 * log10(Sum(*rxPsd) * 180e3) << " dB");
 
     // compute the SNR

--- a/spectrum/model/nyu-channel-model.cc
+++ b/spectrum/model/nyu-channel-model.cc
@@ -891,8 +891,8 @@ NYUChannelModel::GetNewChannel (Ptr<const NYUChannelParams> channelParams,
   //Step 11: Generate channel coefficients for each ray n and each receiver
   // and transmitter element pair u,s.
   
-  uint64_t uSize = uAntenna->GetNumberOfElements ();
-  uint64_t sSize = sAntenna->GetNumberOfElements ();
+  uint64_t uSize = uAntenna->GetNumElems ();
+  uint64_t sSize = sAntenna->GetNumElems ();
 
   Complex3DVector hUsn(uSize,sSize,channelParams->totalSubpaths); //channel coffecient hUsn[u][s][n];
 
@@ -1976,9 +1976,10 @@ NYUChannelModel::GetBWAdjustedtedPowerSpectrum (MatrixBasedChannelModel::Double2
   double BoundaryTime = 0; //All Subpaths <= boundary time are combined together
   double SPcombinedPwr = 0; // Combined complex power of the SP
 
-  std::complex<double> sum_sp = 0; // add the subpath amplitude and phase together
+  std::complex<double> sum_sp; // add the subpath amplitude and phase together
+  sum_sp = 0;
 
-  //bool SetBoundaryTime = true; // indicated a new boundary time is being set.
+  // bool SetBoundaryTime = true; // indicated a new boundary time is being set.
   bool isSubpathCombined = false;
   MatrixBasedChannelModel::Double2DVector powerSpectrum;
 

--- a/spectrum/model/nyu-spectrum-propagation-loss-model.cc
+++ b/spectrum/model/nyu-spectrum-propagation-loss-model.cc
@@ -1,128 +1,137 @@
 /*
-*	Copyright (c) 2023 New York University and NYU WIRELESS
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this
-*	software and associated documentation files (the “Software”), to deal in the Software
-*	without restriction, including without limitation the rights to use, copy, modify,
-*	merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
-*	persons to whom the Software is furnished to do so, subject to the following conditions:
-*	
-*	The above copyright notice and this permission notice shall be included in all copies
-*	or substantial portions of the Software. Users are encouraged to cite NYU WIRELESS 
-*	publications regarding this work.
-*	
-*	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-*	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-*	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-*	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-*	BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
-*	AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-*	IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-*	THE SOFTWARE.
-*
-* Author: Hitesh Poddar <hiteshp@nyu.edu>
-*     
-*/
+ *	Copyright (c) 2023 New York University and NYU WIRELESS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ *	software and associated documentation files (the “Software”), to deal in the Software
+ *	without restriction, including without limitation the rights to use, copy, modify,
+ *	merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ *	persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ *	The above copyright notice and this permission notice shall be included in all copies
+ *	or substantial portions of the Software. Users are encouraged to cite NYU WIRELESS
+ *	publications regarding this work.
+ *
+ *	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ *	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *	BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ *	AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ *	IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *	THE SOFTWARE.
+ *
+ * Author: Hitesh Poddar <hiteshp@nyu.edu>
+ *
+ */
 
-#include "ns3/log.h"
-#include "ns3/nyu-channel-model.h"
 #include "ns3/nyu-spectrum-propagation-loss-model.h"
-#include "ns3/spectrum-signal-parameters.h"
+
+#include "ns3/double.h"
+#include "ns3/log.h"
 #include "ns3/net-device.h"
 #include "ns3/node.h"
-#include "ns3/double.h"
-#include "ns3/string.h"
-#include "ns3/simulator.h"
+#include "ns3/nyu-channel-model.h"
 #include "ns3/pointer.h"
+#include "ns3/simulator.h"
+#include "ns3/spectrum-signal-parameters.h"
+#include "ns3/string.h"
+
 #include <map>
 
-namespace ns3 {
-
-NS_LOG_COMPONENT_DEFINE ("NYUSpectrumPropagationLossModel");
-
-NS_OBJECT_ENSURE_REGISTERED (NYUSpectrumPropagationLossModel);
-
-NYUSpectrumPropagationLossModel::NYUSpectrumPropagationLossModel ()
+namespace ns3
 {
-  NS_LOG_FUNCTION (this);
+
+NS_LOG_COMPONENT_DEFINE("NYUSpectrumPropagationLossModel");
+
+NS_OBJECT_ENSURE_REGISTERED(NYUSpectrumPropagationLossModel);
+
+NYUSpectrumPropagationLossModel::
+NYUSpectrumPropagationLossModel()
+{
+    NS_LOG_FUNCTION(this);
 }
 
-NYUSpectrumPropagationLossModel::~NYUSpectrumPropagationLossModel ()
+NYUSpectrumPropagationLossModel::~
+NYUSpectrumPropagationLossModel()
 {
-  NS_LOG_FUNCTION (this);
+    NS_LOG_FUNCTION(this);
 }
 
 void
-NYUSpectrumPropagationLossModel::DoDispose ()
+NYUSpectrumPropagationLossModel::DoDispose()
 {
-  m_longTermMap.clear ();
-  m_channelModel->Dispose ();
-  m_channelModel = nullptr;
+    m_longTermMap.clear();
+    m_channelModel->Dispose();
+    m_channelModel = nullptr;
 }
 
 TypeId
-NYUSpectrumPropagationLossModel::GetTypeId (void)
+NYUSpectrumPropagationLossModel::GetTypeId()
 {
-  static TypeId tid = TypeId ("ns3::NYUSpectrumPropagationLossModel")
-    .SetParent<PhasedArraySpectrumPropagationLossModel> ()
-    .SetGroupName ("Spectrum")
-    .AddConstructor<NYUSpectrumPropagationLossModel> ()
-    .AddAttribute ("ChannelModel",
-                   "The channel model. It needs to implement the MatrixBasedChannelModel interface",
-                   StringValue ("ns3::NYUChannelModel"),
-                   MakePointerAccessor (&NYUSpectrumPropagationLossModel::SetChannelModel,
-                                        &NYUSpectrumPropagationLossModel::GetChannelModel),
-                   MakePointerChecker<MatrixBasedChannelModel> ())
-  ;
-  return tid;
+    static TypeId tid =
+        TypeId("ns3::NYUSpectrumPropagationLossModel")
+            .SetParent<PhasedArraySpectrumPropagationLossModel>()
+            .SetGroupName("Spectrum")
+            .AddConstructor<NYUSpectrumPropagationLossModel>()
+            .AddAttribute(
+                "ChannelModel",
+                "The channel model. It needs to implement the MatrixBasedChannelModel interface",
+                StringValue("ns3::NYUChannelModel"),
+                MakePointerAccessor(&NYUSpectrumPropagationLossModel::SetChannelModel,
+                                    &NYUSpectrumPropagationLossModel::GetChannelModel),
+                MakePointerChecker<MatrixBasedChannelModel>());
+    return tid;
 }
 
 void
-NYUSpectrumPropagationLossModel::SetChannelModel (Ptr<MatrixBasedChannelModel> channel)
+NYUSpectrumPropagationLossModel::SetChannelModel(Ptr<MatrixBasedChannelModel> channel)
 {
-  m_channelModel = channel;
+    m_channelModel = channel;
 }
 
 Ptr<MatrixBasedChannelModel>
-NYUSpectrumPropagationLossModel::GetChannelModel () const
+NYUSpectrumPropagationLossModel::GetChannelModel() const
 {
-  return m_channelModel;
+    return m_channelModel;
 }
 
 double
-NYUSpectrumPropagationLossModel::GetFrequency () const
+NYUSpectrumPropagationLossModel::GetFrequency() const
 {
-  DoubleValue freq;
-  m_channelModel->GetAttribute ("Frequency", freq);
-  return freq.Get ();
+    DoubleValue freq;
+    m_channelModel->GetAttribute("Frequency", freq);
+    return freq.Get();
 }
 
 void
-NYUSpectrumPropagationLossModel::SetChannelModelAttribute (const std::string &name, const AttributeValue &value)
+NYUSpectrumPropagationLossModel::SetChannelModelAttribute(const std::string& name,
+                                                          const AttributeValue& value)
 {
-  m_channelModel->SetAttribute (name, value);
+    m_channelModel->SetAttribute(name, value);
 }
 
 void
-NYUSpectrumPropagationLossModel::GetChannelModelAttribute (const std::string &name, AttributeValue &value) const
+NYUSpectrumPropagationLossModel::GetChannelModelAttribute(const std::string& name,
+                                                          AttributeValue& value) const
 {
-  m_channelModel->GetAttribute (name, value);
+    m_channelModel->GetAttribute(name, value);
 }
 
 PhasedArrayModel::ComplexVector
-NYUSpectrumPropagationLossModel::CalcLongTerm (Ptr<const MatrixBasedChannelModel::ChannelMatrix> params,
-                                               const PhasedArrayModel::ComplexVector &sW,
-                                               const PhasedArrayModel::ComplexVector &uW) const
+NYUSpectrumPropagationLossModel::CalcLongTerm(
+    Ptr<const MatrixBasedChannelModel::ChannelMatrix> params,
+    const PhasedArrayModel::ComplexVector& sW,
+    const PhasedArrayModel::ComplexVector& uW) const
 {
-  NS_LOG_FUNCTION (this);
+    NS_LOG_FUNCTION(this);
 
-  size_t uAntennaNum = uW.GetSize();
-  size_t sAntennaNum = sW.GetSize();
+    size_t uAntennaNum = uW.GetSize();
+    size_t sAntennaNum = sW.GetSize();
 
-  NS_ASSERT(uAntennaNum == params->m_channel.GetNumRows());
-  NS_ASSERT(sAntennaNum == params->m_channel.GetNumCols());
+    NS_ASSERT(uAntennaNum == params->m_channel.GetNumRows());
+    NS_ASSERT(sAntennaNum == params->m_channel.GetNumCols());
 
- NS_LOG_DEBUG("CalcLongTerm with " << uAntennaNum << " u antenna elements and " << sAntennaNum
+    NS_LOG_DEBUG("CalcLongTerm with " << uAntennaNum << " u antenna elements and " << sAntennaNum
                                       << " s antenna elements.");
     // store the long term part to reduce computation load
     // only the small scale fading needs to be updated if the large scale parameters and antenna
@@ -132,201 +141,225 @@ NYUSpectrumPropagationLossModel::CalcLongTerm (Ptr<const MatrixBasedChannelModel
 }
 
 Ptr<SpectrumValue>
-NYUSpectrumPropagationLossModel::CalcBeamformingGain (Ptr<SpectrumValue> txPsd,
-                                                      PhasedArrayModel::ComplexVector longTerm,
-                                                      Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
-                                                      Ptr<const MatrixBasedChannelModel::ChannelParams> channelParams,
-                                                      const ns3::Vector &sSpeed,
-                                                      const ns3::Vector &uSpeed) const
+NYUSpectrumPropagationLossModel::CalcBeamformingGain(
+    Ptr<SpectrumValue> txPsd,
+    PhasedArrayModel::ComplexVector longTerm,
+    Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
+    Ptr<const MatrixBasedChannelModel::ChannelParams> channelParams,
+    const ns3::Vector& sSpeed,
+    const ns3::Vector& uSpeed) const
 {
-  NS_LOG_FUNCTION (this);
+    NS_LOG_FUNCTION(this);
 
-  Ptr<SpectrumValue> tempPsd = Copy<SpectrumValue> (txPsd);
+    Ptr<SpectrumValue> tempPsd = Copy<SpectrumValue>(txPsd);
 
-  //channel[rx][tx][cluster]
-  uint16_t numRays = channelMatrix->m_channel.GetNumPages();
+    // channel[rx][tx][cluster]
+    uint16_t numRays = channelMatrix->m_channel.GetNumPages();
 
-  // compute the doppler term
-  // NOTE the update of Doppler is simplified by only taking the center angle of
-  // each cluster in to consideration.
-  double slotTime = Simulator::Now ().GetSeconds ();
-  double factor = 2 * M_PI * slotTime * GetFrequency () / 3e8;
-  PhasedArrayModel::ComplexVector doppler(numRays);
+    // compute the doppler term
+    // NOTE the update of Doppler is simplified by only taking the center angle of
+    // each cluster in to consideration.
+    double slotTime = Simulator::Now().GetSeconds();
+    double factor = 2 * M_PI * slotTime * GetFrequency() / 3e8;
+    PhasedArrayModel::ComplexVector doppler(numRays);
 
-  // check if channelParams structure is generated in direction s-to-u or u-to-s
-  bool isSameDirection = (channelParams->m_nodeIds == channelMatrix->m_nodeIds);
+    // check if channelParams structure is generated in direction s-to-u or u-to-s
+    bool isSameDirection = (channelParams->m_nodeIds == channelMatrix->m_nodeIds);
 
-  MatrixBasedChannelModel::DoubleVector zoa;
-  MatrixBasedChannelModel::DoubleVector zod;
-  MatrixBasedChannelModel::DoubleVector aoa;
-  MatrixBasedChannelModel::DoubleVector aod;
+    MatrixBasedChannelModel::DoubleVector zoa;
+    MatrixBasedChannelModel::DoubleVector zod;
+    MatrixBasedChannelModel::DoubleVector aoa;
+    MatrixBasedChannelModel::DoubleVector aod;
 
-  // if channel params is generated in the same direction in which we
-  // generate the channel matrix, angles and zenit od departure and arrival are ok,
-  // just set them to corresponding variable that will be used for the generation
-  // of channel matrix, otherwise we need to flip angles and zenits of departure and arrival
-  if (isSameDirection)
+    // if channel params is generated in the same direction in which we
+    // generate the channel matrix, angles and zenit od departure and arrival are ok,
+    // just set them to corresponding variable that will be used for the generation
+    // of channel matrix, otherwise we need to flip angles and zenits of departure and arrival
+    if (isSameDirection)
     {
-      zoa = channelParams->m_angle[MatrixBasedChannelModel::ZOA_INDEX];
-      zod = channelParams->m_angle[MatrixBasedChannelModel::ZOD_INDEX];
-      aoa = channelParams->m_angle[MatrixBasedChannelModel::AOA_INDEX];
-      aod = channelParams->m_angle[MatrixBasedChannelModel::AOD_INDEX];
+        zoa = channelParams->m_angle[MatrixBasedChannelModel::ZOA_INDEX];
+        zod = channelParams->m_angle[MatrixBasedChannelModel::ZOD_INDEX];
+        aoa = channelParams->m_angle[MatrixBasedChannelModel::AOA_INDEX];
+        aod = channelParams->m_angle[MatrixBasedChannelModel::AOD_INDEX];
     }
-  else
+    else
     {
-      zod = channelParams->m_angle[MatrixBasedChannelModel::ZOA_INDEX];
-      zoa = channelParams->m_angle[MatrixBasedChannelModel::ZOD_INDEX];
-      aod = channelParams->m_angle[MatrixBasedChannelModel::AOA_INDEX];
-      aoa = channelParams->m_angle[MatrixBasedChannelModel::AOD_INDEX];
-    }
-
-  for (uint8_t cIndex = 0; cIndex < numRays; cIndex++)
-    {
-      // Compute alpha and D as described in 3GPP TR 37.885 v15.3.0, Sec. 6.2.3
-      // These terms account for an additional Doppler contribution due to the
-      // presence of moving objects in the sorrounding environment, such as in
-      // vehicular scenarios.
-      // This contribution is applied only to the delayed (reflected) paths and
-      // must be properly configured by setting the value of
-      // m_vScatt, which is defined as "maximum speed of the vehicle in the
-      // layout".
-      // By default, m_vScatt is set to 0, so there is no additional Doppler
-      // contribution.
-
-      //cluster angle angle[direction][n], where direction = 0(aoa), 1(zoa).
-      double tempDoppler = factor * ((sin (zoa [cIndex]) * cos (aoa [cIndex] ) * uSpeed.x
-                                      + sin (zoa [cIndex] ) * sin (aoa [cIndex] ) * uSpeed.y
-                                      + cos (zoa [cIndex] ) * uSpeed.z)
-                                     + (sin (zod [cIndex] ) * cos (aod [cIndex] ) * sSpeed.x
-                                        + sin (zod [cIndex] ) * sin (aod [cIndex] ) * sSpeed.y
-                                        + cos (zod [cIndex] ) * sSpeed.z));
-      doppler[cIndex] =  std::complex<double> (cos (tempDoppler), sin (tempDoppler));
+        zod = channelParams->m_angle[MatrixBasedChannelModel::ZOA_INDEX];
+        zoa = channelParams->m_angle[MatrixBasedChannelModel::ZOD_INDEX];
+        aod = channelParams->m_angle[MatrixBasedChannelModel::AOA_INDEX];
+        aoa = channelParams->m_angle[MatrixBasedChannelModel::AOD_INDEX];
     }
 
-  NS_ASSERT(numRays <= doppler.GetSize());
-
-  // apply the doppler term and the propagation delay to the long term component
-  // to obtain the beamforming gain
-  auto vit = tempPsd->ValuesBegin (); // psd iterator
-  auto sbit = tempPsd->ConstBandsBegin (); // band iterator
-  while (vit != tempPsd->ValuesEnd ())
+    for (uint8_t cIndex = 0; cIndex < numRays; cIndex++)
     {
-      if ((*vit) != 0.00)
+        // Compute alpha and D as described in 3GPP TR 37.885 v15.3.0, Sec. 6.2.3
+        // These terms account for an additional Doppler contribution due to the
+        // presence of moving objects in the sorrounding environment, such as in
+        // vehicular scenarios.
+        // This contribution is applied only to the delayed (reflected) paths and
+        // must be properly configured by setting the value of
+        // m_vScatt, which is defined as "maximum speed of the vehicle in the
+        // layout".
+        // By default, m_vScatt is set to 0, so there is no additional Doppler
+        // contribution.
+
+        // cluster angle angle[direction][n], where direction = 0(aoa), 1(zoa).
+        double tempDoppler =
+            factor *
+            ((sin(zoa[cIndex]) * cos(aoa[cIndex]) * uSpeed.x +
+              sin(zoa[cIndex]) * sin(aoa[cIndex]) * uSpeed.y + cos(zoa[cIndex]) * uSpeed.z) +
+             (sin(zod[cIndex]) * cos(aod[cIndex]) * sSpeed.x +
+              sin(zod[cIndex]) * sin(aod[cIndex]) * sSpeed.y + cos(zod[cIndex]) * sSpeed.z));
+        doppler[cIndex] = std::complex<double>(cos(tempDoppler), sin(tempDoppler));
+    }
+
+    NS_ASSERT(numRays <= doppler.GetSize());
+
+    // apply the doppler term and the propagation delay to the long term component
+    // to obtain the beamforming gain
+    auto vit = tempPsd->ValuesBegin();      // psd iterator
+    auto sbit = tempPsd->ConstBandsBegin(); // band iterator
+    while (vit != tempPsd->ValuesEnd())
+    {
+        if ((*vit) != 0.00)
         {
-          std::complex<double> subsbandGain (0.0, 0.0);
-          double fsb = (*sbit).fc; // center frequency of the sub-band
-          for (uint8_t cIndex = 0; cIndex < numRays; cIndex++)
+            std::complex<double> subsbandGain(0.0, 0.0);
+            double fsb = (*sbit).fc; // center frequency of the sub-band
+            for (uint8_t cIndex = 0; cIndex < numRays; cIndex++)
             {
-              double delay = -2 * M_PI * fsb * (channelParams->m_delay[cIndex]) * 1e-9;
-              subsbandGain = subsbandGain + longTerm[cIndex] * std::complex<double> (cos (delay), sin (delay)) * doppler[cIndex];
+                double delay = -2 * M_PI * fsb * (channelParams->m_delay[cIndex]) * 1e-9;
+                subsbandGain = subsbandGain + longTerm[cIndex] *
+                                                  std::complex<double>(cos(delay), sin(delay)) *
+                                                  doppler[cIndex];
             }
-          *vit = (*vit) * (norm (subsbandGain));
+            *vit = (*vit) * (norm(subsbandGain));
         }
-      vit++;
-      sbit++;
+        vit++;
+        sbit++;
     }
-  return tempPsd;
+    return tempPsd;
 }
 
 PhasedArrayModel::ComplexVector
-NYUSpectrumPropagationLossModel::GetLongTerm (Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
-                                              Ptr<const PhasedArrayModel> aPhasedArrayModel,
-                                              Ptr<const PhasedArrayModel> bPhasedArrayModel) const
+NYUSpectrumPropagationLossModel::GetLongTerm(
+    Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
+    Ptr<const PhasedArrayModel> aPhasedArrayModel,
+    Ptr<const PhasedArrayModel> bPhasedArrayModel) const
 {
-  PhasedArrayModel::ComplexVector longTerm; // vector containing the long term component for each cluster
+    PhasedArrayModel::ComplexVector
+        longTerm; // vector containing the long term component for each cluster
 
-  // check if the channel matrix was generated considering a as the s-node and
-  // b as the u-node or viceversa
-  PhasedArrayModel::ComplexVector sW, uW;
-  if (!channelMatrix->IsReverse (aPhasedArrayModel->GetId (), bPhasedArrayModel->GetId ()))
+    // check if the channel matrix was generated considering a as the s-node and
+    // b as the u-node or viceversa
+    PhasedArrayModel::ComplexVector sW, uW;
+    if (!channelMatrix->IsReverse(aPhasedArrayModel->GetId(), bPhasedArrayModel->GetId()))
     {
-      sW = aPhasedArrayModel->GetBeamformingVector ();
-      uW = bPhasedArrayModel->GetBeamformingVector ();
+        sW = aPhasedArrayModel->GetBeamformingVector();
+        uW = bPhasedArrayModel->GetBeamformingVector();
     }
-  else
+    else
     {
-      sW = bPhasedArrayModel->GetBeamformingVector ();
-      uW = aPhasedArrayModel->GetBeamformingVector ();
-    }
-
-  bool update = false; // indicates whether the long term has to be updated
-  bool notFound = false; // indicates if the long term has not been computed yet
-
-  // compute the long term key, the key is unique for each tx-rx pair
-  uint64_t longTermId = MatrixBasedChannelModel::GetKey (aPhasedArrayModel->GetId (), bPhasedArrayModel->GetId ());
-
-  // look for the long term in the map and check if it is valid
-  if (m_longTermMap.find (longTermId) != m_longTermMap.end ())
-    {
-      NS_LOG_DEBUG ("found the long term component in the map");
-      longTerm = m_longTermMap[longTermId]->m_longTerm;
-
-      // check if the channel matrix has been updated
-      // or the s beam has been changed
-      // or the u beam has been changed
-      update = (m_longTermMap[longTermId]->m_channel->m_generatedTime != channelMatrix->m_generatedTime
-                || m_longTermMap[longTermId]->m_sW != sW
-                || m_longTermMap[longTermId]->m_uW != uW);
-
-    }
-  else
-    {
-      NS_LOG_DEBUG ("long term component NOT found");
-      notFound = true;
+        sW = bPhasedArrayModel->GetBeamformingVector();
+        uW = aPhasedArrayModel->GetBeamformingVector();
     }
 
-  if (update || notFound)
+    bool update = false;   // indicates whether the long term has to be updated
+    bool notFound = false; // indicates if the long term has not been computed yet
+
+    // compute the long term key, the key is unique for each tx-rx pair
+    uint64_t longTermId =
+        MatrixBasedChannelModel::GetKey(aPhasedArrayModel->GetId(), bPhasedArrayModel->GetId());
+
+    // look for the long term in the map and check if it is valid
+    if (m_longTermMap.find(longTermId) != m_longTermMap.end())
     {
-      NS_LOG_DEBUG ("compute the long term");
-      // compute the long term component
-      longTerm = CalcLongTerm (channelMatrix, sW, uW);
+        NS_LOG_DEBUG("found the long term component in the map");
+        longTerm = m_longTermMap[longTermId]->m_longTerm;
 
-      // store the long term
-      Ptr<LongTerm> longTermItem = Create<LongTerm> ();
-      longTermItem->m_longTerm = longTerm;
-      longTermItem->m_channel = channelMatrix;
-      longTermItem->m_sW = sW;
-      longTermItem->m_uW = uW;
-
-      m_longTermMap[longTermId] = longTermItem;
+        // check if the channel matrix has been updated
+        // or the s beam has been changed
+        // or the u beam has been changed
+        update = (m_longTermMap[longTermId]->m_channel->m_generatedTime !=
+                      channelMatrix->m_generatedTime ||
+                  m_longTermMap[longTermId]->m_sW != sW || m_longTermMap[longTermId]->m_uW != uW);
+    }
+    else
+    {
+        NS_LOG_DEBUG("long term component NOT found");
+        notFound = true;
     }
 
-  return longTerm;
+    if (update || notFound)
+    {
+        NS_LOG_DEBUG("compute the long term");
+        // compute the long term component
+        longTerm = CalcLongTerm(channelMatrix, sW, uW);
+
+        // store the long term
+        Ptr<LongTerm> longTermItem = Create<LongTerm>();
+        longTermItem->m_longTerm = longTerm;
+        longTermItem->m_channel = channelMatrix;
+        longTermItem->m_sW = sW;
+        longTermItem->m_uW = uW;
+
+        m_longTermMap[longTermId] = longTermItem;
+    }
+
+    return longTerm;
 }
 
-Ptr<SpectrumValue>
-NYUSpectrumPropagationLossModel::DoCalcRxPowerSpectralDensity (Ptr<const SpectrumSignalParameters> params,
-                                                               Ptr<const MobilityModel> a,
-                                                               Ptr<const MobilityModel> b,
-                                                               Ptr<const PhasedArrayModel> aPhasedArrayModel,
-                                                               Ptr<const PhasedArrayModel> bPhasedArrayModel) const
+Ptr<SpectrumSignalParameters>
+NYUSpectrumPropagationLossModel::DoCalcRxPowerSpectralDensity(
+    Ptr<const SpectrumSignalParameters> params,
+    Ptr<const MobilityModel> a,
+    Ptr<const MobilityModel> b,
+    Ptr<const PhasedArrayModel> aPhasedArrayModel,
+    Ptr<const PhasedArrayModel> bPhasedArrayModel) const
 {
-  NS_LOG_FUNCTION (this);
-  uint32_t aId = a->GetObject<Node> ()->GetId (); // id of the node a
-  uint32_t bId = b->GetObject<Node> ()->GetId (); // id of the node b
+    NS_LOG_FUNCTION(this);
+    uint32_t aId = a->GetObject<Node>()->GetId(); // id of the node a
+    uint32_t bId = b->GetObject<Node>()->GetId(); // id of the node b
 
-  NS_ASSERT (aId != bId);
-  NS_ASSERT_MSG (a->GetDistanceFrom (b) > 0.0, "The position of a and b devices cannot be the same");
+    NS_ASSERT(aId != bId);
+    NS_ASSERT_MSG(a->GetDistanceFrom(b) > 0.0,
+                  "The position of a and b devices cannot be the same");
 
-  Ptr<SpectrumValue> rxPsd = Copy<SpectrumValue>(params->psd);
+    Ptr<SpectrumValue> rxPsd = Copy<SpectrumValue>(params->psd);
 
-  // retrieve the antenna of device a
-  NS_ASSERT_MSG (aPhasedArrayModel, "Antenna not found for node " << aId);
+    // retrieve the antenna of device a
+    NS_ASSERT_MSG(aPhasedArrayModel, "Antenna not found for node " << aId);
 
-  // retrieve the antenna of the device b
-  NS_ASSERT_MSG (bPhasedArrayModel, "Antenna not found for device " << bId);
+    // retrieve the antenna of the device b
+    NS_ASSERT_MSG(bPhasedArrayModel, "Antenna not found for device " << bId);
 
-  Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix = m_channelModel->GetChannel (a, b, aPhasedArrayModel, bPhasedArrayModel);
-  Ptr<const MatrixBasedChannelModel::ChannelParams> channelParams = m_channelModel->GetParams (a, b);
+    Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix =
+        m_channelModel->GetChannel(a, b, aPhasedArrayModel, bPhasedArrayModel);
+    Ptr<const MatrixBasedChannelModel::ChannelParams> channelParams =
+        m_channelModel->GetParams(a, b);
 
-  // retrieve the long term component
-  PhasedArrayModel::ComplexVector longTerm = GetLongTerm (channelMatrix, aPhasedArrayModel, bPhasedArrayModel);
+    // retrieve the long term component
+    PhasedArrayModel::ComplexVector longTerm =
+        GetLongTerm(channelMatrix, aPhasedArrayModel, bPhasedArrayModel);
 
-  // apply the beamforming gain
-  rxPsd = CalcBeamformingGain (rxPsd, longTerm, channelMatrix, channelParams, a->GetVelocity (), b->GetVelocity ());
+    // apply the beamforming gain
+    rxPsd = CalcBeamformingGain(rxPsd,
+                                longTerm,
+                                channelMatrix,
+                                channelParams,
+                                a->GetVelocity(),
+                                b->GetVelocity());
 
-  return rxPsd;
+    // return rxPsd;
+    Ptr<SpectrumSignalParameters> rxParams = Create<SpectrumSignalParameters>();
+    rxParams->psd = rxPsd;
+    return rxParams;
 }
 
+int64_t
+NYUSpectrumPropagationLossModel::DoAssignStreams(int64_t stream)
+{
+    m_randVariable->SetStream(stream);
+    return 1;
+}
 
-}  // namespace ns3
+} // namespace ns3

--- a/spectrum/model/nyu-spectrum-propagation-loss-model.h
+++ b/spectrum/model/nyu-spectrum-propagation-loss-model.h
@@ -1,40 +1,42 @@
 /*
-*	Copyright (c) 2023 New York University and NYU WIRELESS
-*
-* Permission is hereby granted, free of charge, to any person obtaining a copy of this
-*	software and associated documentation files (the “Software”), to deal in the Software
-*	without restriction, including without limitation the rights to use, copy, modify,
-*	merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
-*	persons to whom the Software is furnished to do so, subject to the following conditions:
-*	
-*	The above copyright notice and this permission notice shall be included in all copies
-*	or substantial portions of the Software. Users are encouraged to cite NYU WIRELESS 
-*	publications regarding this work.
-*	
-*	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-*	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-*	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-*	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-*	BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
-*	AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-*	IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-*	THE SOFTWARE.
-*
-* Author: Hitesh Poddar <hiteshp@nyu.edu>
-*     
-*/
+ *	Copyright (c) 2023 New York University and NYU WIRELESS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ *	software and associated documentation files (the “Software”), to deal in the Software
+ *	without restriction, including without limitation the rights to use, copy, modify,
+ *	merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+ *	persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ *	The above copyright notice and this permission notice shall be included in all copies
+ *	or substantial portions of the Software. Users are encouraged to cite NYU WIRELESS
+ *	publications regarding this work.
+ *
+ *	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ *	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *	OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ *	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *	BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ *	AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ *	IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *	THE SOFTWARE.
+ *
+ * Author: Hitesh Poddar <hiteshp@nyu.edu>
+ *
+ */
 
 #ifndef NYU_SPECTRUM_PROPAGATION_LOSS_H
 #define NYU_SPECTRUM_PROPAGATION_LOSS_H
 
+#include "ns3/matrix-based-channel-model.h"
+#include "ns3/phased-array-spectrum-propagation-loss-model.h"
+#include "ns3/random-variable-stream.h"
+
 #include <complex.h>
 #include <map>
 #include <unordered_map>
-#include "ns3/matrix-based-channel-model.h"
-#include "ns3/random-variable-stream.h"
-#include "ns3/phased-array-spectrum-propagation-loss-model.h"
 
-namespace ns3 {
+namespace ns3
+{
 
 class NetDevice;
 
@@ -54,140 +56,152 @@ class NetDevice;
  */
 class NYUSpectrumPropagationLossModel : public PhasedArraySpectrumPropagationLossModel
 {
-public:
-  /**
-   * Constructor
-   */
-  NYUSpectrumPropagationLossModel ();
+  public:
+    /**
+     * Constructor
+     */
+    NYUSpectrumPropagationLossModel();
 
-  /**
-   * Destructor
-   */
-  ~NYUSpectrumPropagationLossModel ();
+    /**
+     * Destructor
+     */
+    virtual ~NYUSpectrumPropagationLossModel();
 
-  void DoDispose () override;
+    void DoDispose() override;
 
-  /**
-   * Get the type ID.
-   * \return the object TypeId
-   */
-  static TypeId GetTypeId ();
+    /**
+     * Get the type ID.
+     * \return the object TypeId
+     */
+    static TypeId GetTypeId();
 
-  /**
-   * Set the channel model object
-   * \param channel a pointer to an object implementing the MatrixBasedChannelModel interface
-   */
-  void SetChannelModel (Ptr<MatrixBasedChannelModel> channel);
+    /**
+     * Set the channel model object
+     * \param channel a pointer to an object implementing the MatrixBasedChannelModel interface
+     */
+    void SetChannelModel(Ptr<MatrixBasedChannelModel> channel);
 
-  /**
-   * Get the channel model object
-   * \return a pointer to the object implementing the MatrixBasedChannelModel interface
-   */
-  Ptr<MatrixBasedChannelModel> GetChannelModel () const;
+    /**
+     * Get the channel model object
+     * \return a pointer to the object implementing the MatrixBasedChannelModel interface
+     */
+    Ptr<MatrixBasedChannelModel> GetChannelModel() const;
 
-  /**
-   * Sets the value of an attribute belonging to the associated
-   * MatrixBasedChannelModel instance
-   * \param name name of the attribute
-   * \param value the attribute value
-   */
-  void SetChannelModelAttribute (const std::string &name, const AttributeValue &value);
+    /**
+     * Sets the value of an attribute belonging to the associated
+     * MatrixBasedChannelModel instance
+     * \param name name of the attribute
+     * \param value the attribute value
+     */
+    void SetChannelModelAttribute(const std::string& name, const AttributeValue& value);
 
-  /**
-   * Returns the value of an attribute belonging to the associated
-   * MatrixBasedChannelModel instance
-   * \param name name of the attribute
-   * \param value where the result should be stored
-   */
-  void GetChannelModelAttribute (const std::string &name, AttributeValue &value) const;
+    /**
+     * Returns the value of an attribute belonging to the associated
+     * MatrixBasedChannelModel instance
+     * \param name name of the attribute
+     * \param value where the result should be stored
+     */
+    void GetChannelModelAttribute(const std::string& name, AttributeValue& value) const;
 
-  /**
-   * \brief Computes the received PSD.
-   *
-   * This function computes the received PSD by applying the 3GPP fast fading
-   * model and the beamforming gain.
-   * In particular, it retrieves the matrix representing the channel between
-   * node a and node b, computes the corresponding long term component, i.e.,
-   * the product between the cluster matrices and the TX and RX beamforming
-   * vectors (w_rx^T H^n_ab w_tx), and accounts for the Doppler component and
-   * the propagation delay.
-   * To reduce the computational load, the long term component associated with
-   * a certain channel is cached and recomputed only when the channel realization
-   * is updated, or when the beamforming vectors change.
-   *
-   * \param txPsd tx PSD
-   * \param a first node mobility model
-   * \param b second node mobility model
-   * \param aPhasedArrayModel the antenna array of the first node
-   * \param bPhasedArrayModel the antenna array of the second node
-   * \return the received PSD
-   */
-  Ptr<SpectrumValue> DoCalcRxPowerSpectralDensity (Ptr<const SpectrumSignalParameters> params,
-                                                   Ptr<const MobilityModel> a,
-                                                   Ptr<const MobilityModel> b,
-                                                   Ptr<const PhasedArrayModel> aPhasedArrayModel,
-                                                   Ptr<const PhasedArrayModel> bPhasedArrayModel) const override;
+    /**
+     * \brief Computes the received PSD.
+     *
+     * This function computes the received PSD by applying the 3GPP fast fading
+     * model and the beamforming gain.
+     * In particular, it retrieves the matrix representing the channel between
+     * node a and node b, computes the corresponding long term component, i.e.,
+     * the product between the cluster matrices and the TX and RX beamforming
+     * vectors (w_rx^T H^n_ab w_tx), and accounts for the Doppler component and
+     * the propagation delay.
+     * To reduce the computational load, the long term component associated with
+     * a certain channel is cached and recomputed only when the channel realization
+     * is updated, or when the beamforming vectors change.
+     *
+     * \param txPsd tx PSD
+     * \param a first node mobility model
+     * \param b second node mobility model
+     * \param aPhasedArrayModel the antenna array of the first node
+     * \param bPhasedArrayModel the antenna array of the second node
+     * \return the received PSD
+     */
+    virtual Ptr<SpectrumSignalParameters> DoCalcRxPowerSpectralDensity(
+        Ptr<const SpectrumSignalParameters> params,
+        Ptr<const MobilityModel> a,
+        Ptr<const MobilityModel> b,
+        Ptr<const PhasedArrayModel> aPhasedArrayModel,
+        Ptr<const PhasedArrayModel> bPhasedArrayModel) const override;
 
-private:
-  /**
-   * Data structure that stores the long term component for a tx-rx pair
-   */
-  struct LongTerm : public SimpleRefCount<LongTerm>
-  {
-    PhasedArrayModel::ComplexVector m_longTerm; //!< vector containing the long term component for each cluster
-    Ptr<const MatrixBasedChannelModel::ChannelMatrix> m_channel; //!< pointer to the channel matrix used to compute the long term
-    PhasedArrayModel::ComplexVector m_sW; //!< the beamforming vector for the node s used to compute the long term
-    PhasedArrayModel::ComplexVector m_uW; //!< the beamforming vector for the node u used to compute the long term
-  };
+    virtual int64_t DoAssignStreams(int64_t stream) override;
 
-  /**
-   * Get the operating frequency
-   * \return the operating frequency in Hz
-  */
-  double GetFrequency () const;
+  private:
+    /**
+     * Data structure that stores the long term component for a tx-rx pair
+     */
+    struct LongTerm : public SimpleRefCount<LongTerm>
+    {
+        PhasedArrayModel::ComplexVector
+            m_longTerm; //!< vector containing the long term component for each cluster
+        Ptr<const MatrixBasedChannelModel::ChannelMatrix>
+            m_channel; //!< pointer to the channel matrix used to compute the long term
+        PhasedArrayModel::ComplexVector
+            m_sW; //!< the beamforming vector for the node s used to compute the long term
+        PhasedArrayModel::ComplexVector
+            m_uW; //!< the beamforming vector for the node u used to compute the long term
+    };
 
-  /**
-   * Looks for the long term component in m_longTermMap. If found, checks
-   * whether it has to be updated. If not found or if it has to be updated,
-   * calls the method CalcLongTerm to compute it.
-   * \param channelMatrix the channel matrix
-   * \param aPhasedArrayModel the antenna array of the tx device
-   * \param bPhasedArrayModel the antenna array of the rx device
-   * \return vector containing the long term component for each cluster
-   */
-  PhasedArrayModel::ComplexVector GetLongTerm (Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
-                                               Ptr<const PhasedArrayModel> aPhasedArrayModel,
-                                               Ptr<const PhasedArrayModel> bPhasedArrayModel) const;
-  /**
-   * Computes the long term component
-   * \param channelMatrix the channel matrix H
-   * \param sW the beamforming vector of the s device
-   * \param uW the beamforming vector of the u device
-   * \return the long term component
-   */
-  PhasedArrayModel::ComplexVector CalcLongTerm (Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
-                                                const PhasedArrayModel::ComplexVector &sW,
-                                                const PhasedArrayModel::ComplexVector &uW) const;
+    /**
+     * Get the operating frequency
+     * \return the operating frequency in Hz
+     */
+    double GetFrequency() const;
 
-  /**
-   * Computes the beamforming gain and applies it to the tx PSD
-   * \param txPsd the tx PSD
-   * \param longTerm the long term component
-   * \param channelMatrix The channel matrix structure
-   * \param channelParams The channel params structure
-   * \param sSpeed speed of the first node
-   * \param uSpeed speed of the second node
-   * \return the rx PSD
-   */
-  Ptr<SpectrumValue> CalcBeamformingGain (Ptr<SpectrumValue> txPsd,
-                                          PhasedArrayModel::ComplexVector longTerm,
-                                          Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
-                                          Ptr<const MatrixBasedChannelModel::ChannelParams> channelParams,
-                                          const Vector &sSpeed, 
-                                          const Vector &uSpeed) const;
+    /**
+     * Looks for the long term component in m_longTermMap. If found, checks
+     * whether it has to be updated. If not found or if it has to be updated,
+     * calls the method CalcLongTerm to compute it.
+     * \param channelMatrix the channel matrix
+     * \param aPhasedArrayModel the antenna array of the tx device
+     * \param bPhasedArrayModel the antenna array of the rx device
+     * \return vector containing the long term component for each cluster
+     */
+    PhasedArrayModel::ComplexVector GetLongTerm(
+        Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
+        Ptr<const PhasedArrayModel> aPhasedArrayModel,
+        Ptr<const PhasedArrayModel> bPhasedArrayModel) const;
+    /**
+     * Computes the long term component
+     * \param channelMatrix the channel matrix H
+     * \param sW the beamforming vector of the s device
+     * \param uW the beamforming vector of the u device
+     * \return the long term component
+     */
+    PhasedArrayModel::ComplexVector CalcLongTerm(
+        Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
+        const PhasedArrayModel::ComplexVector& sW,
+        const PhasedArrayModel::ComplexVector& uW) const;
 
-  mutable std::unordered_map < uint64_t, Ptr<const LongTerm> > m_longTermMap; //!< map containing the long term components
-  Ptr<MatrixBasedChannelModel> m_channelModel; //!< the model to generate the channel matrix
+    /**
+     * Computes the beamforming gain and applies it to the tx PSD
+     * \param txPsd the tx PSD
+     * \param longTerm the long term component
+     * \param channelMatrix The channel matrix structure
+     * \param channelParams The channel params structure
+     * \param sSpeed speed of the first node
+     * \param uSpeed speed of the second node
+     * \return the rx PSD
+     */
+    Ptr<SpectrumValue> CalcBeamformingGain(
+        Ptr<SpectrumValue> txPsd,
+        PhasedArrayModel::ComplexVector longTerm,
+        Ptr<const MatrixBasedChannelModel::ChannelMatrix> channelMatrix,
+        Ptr<const MatrixBasedChannelModel::ChannelParams> channelParams,
+        const Vector& sSpeed,
+        const Vector& uSpeed) const;
+
+    mutable std::unordered_map<uint64_t, Ptr<const LongTerm>>
+        m_longTermMap;                           //!< map containing the long term components
+    Ptr<MatrixBasedChannelModel> m_channelModel; //!< the model to generate the channel matrix
+    Ptr<NormalRandomVariable> m_randVariable;    //!< Random variable
 };
 } // namespace ns3
 


### PR DESCRIPTION
Description: This pull request introduces an update to the NYUSIM simulator, making it compatible with ns3-3.42. Major changes include:

+ Modified code to ensure compatibility with the latest ns-3 APIs.
  + Updated files:
    + `nyu-channel-model.cc`: ` Ptr<const PhasedArrayModel> uAntenna->GetNumberOfElements()` to `GetNumElems()` for compatibility;
    + `nyu-spectrum-propagation-loss-model.cc`:
      + Method signature changes:
        `Ptr<SpectrumValue>
        NYUSpectrumPropagationLossModel::DoCalcRxPowerSpectralDensity` --> `Ptr<SpectrumSignalParameters>
        NYUSpectrumPropagationLossModel::DoCalcRxPowerSpectralDensity`
      + Adjusted method return for compatibility with `SpectrumSignalParameters`
      + Adjusted `DoAssignStreams` method
    + `nyu-spectrum-propagation-loss-model.h`:
      + Add virtual to class destructor and `DoCalcRxPowerSpectralDensity` and `DoAssignStreams` methods
      + `DoCalcRxPowerSpectralDensity` method signature changes
+ Integration tested to confirm that all functionality remains operational with the new ns-3 version.
+ Fixed minor bugs found during testing.
+ These updates are intended to keep the NYUSIM simulator functional with the latest versions of ns-3, ensuring that the tool remains functional for the research community.

Please review the changes and let me know if any additional modifications or improvements are needed.

I would greatly appreciate your feedback.